### PR TITLE
Add support for remote sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This driver is designed to work with [mitsubishi_heatpump_mqtt_esp8266_esp32](ht
 - Can detect when the heatpumps are actively heating/cooling and update Hubitat Dashboard
 - Reports room temperature back from the heatpump for use in automations
 - Supports all heatpump modes and fan speeds
+- Supports remote temperature (because internal heat pump sensors can be inaccurate)
 
 ## Prerequisites
 

--- a/hubitat-mitsubishi-mqtt.groovy
+++ b/hubitat-mitsubishi-mqtt.groovy
@@ -30,9 +30,10 @@
  * SOFTWARE.
  */
 
-import groovy.transform.Field
-import groovy.json.JsonSlurper
+
 import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+import groovy.transform.Field
 
 @Field static List<String> supportedThermostatFanModes = ['auto', 'quiet', '1', '2', '3', '4']
 @Field static List<String> supportedThermostatModes = ['auto', 'off', 'cool', 'heat', 'fan', 'dry']
@@ -314,13 +315,16 @@ void setHeatingSetpoint(BigDecimal setpoint) {
 
 void setRemoteTemperature(BigDecimal temperature) {
     if (temperature != null) {
+        // 0 tells the code on the HP to switch to the internal sensor
         BigDecimal remoteTemp = temperature == 0 ? 0 : convertInputToCelsius(temperature)
         def thermostatOperatingState = device.currentValue('thermostatOperatingState')
         // Add or subtract 0.5C while operating to actually get it to turn off closer to the desired setpoint
-        if (thermostatOperatingState == "heating") {
-            remoteTemp += 0.5
-        } else if (thermostatOperatingState == "cooling") {
-            remoteTemp -= 0.5
+        if (remoteTemp != 0) {
+            if (thermostatOperatingState == "heating") {
+                remoteTemp += 0.5
+            } else if (thermostatOperatingState == "cooling") {
+                remoteTemp -= 0.5
+            }
         }
         sendEvent([name: 'remoteTemperature', value: remoteTemp])
         publish(['remoteTemp': remoteTemp])

--- a/hubitat-mitsubishi-mqtt.groovy
+++ b/hubitat-mitsubishi-mqtt.groovy
@@ -72,7 +72,7 @@ import groovy.json.JsonOutput
 
 metadata {
     definition(
-        name: 'Mitsubishi Heat Pump + MQTT',
+        name: 'Mitsubishi Heat Pump MQTT',
         namespace: 'cogdev',
         author: 'Seth Kinast <seth@cogdev.net>',
         importUrl:


### PR DESCRIPTION
Add a setRemoteTemperature custom action to allow Rule Machine (or an app) to utilize an external temperature sensor in the Arduino code.

I needed to remove the '+' from the driver name so that my new [Remote Sensor](https://github.com/randalln/hubitat-mitsubishi-mqtt-remote-app) companion app can find matching devices.